### PR TITLE
3 feat create customer subscription

### DIFF
--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -16,7 +16,9 @@ module Api
       private
 
       def subscription_params
-        params[:frequency] = params[:frequency].to_i 
+        if params[:frequency]
+          params[:frequency] = params[:frequency].to_i 
+        end
         params.permit(:title, :price, :frequency, :customer_id, :tea_id, :active)
       end
 

--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -1,13 +1,23 @@
 module Api
   module V1
     class SubscriptionsController < ApplicationController
-      before_action :find_customer, only: :index
+      before_action :find_customer, only: [:index, :create]
 
       def index
         render json: SubscriptionSerializer.new(@customer.subscriptions), status: :ok
       end
 
+      def create
+        @customer.subscriptions.create!(subscription_params)
+        render json: { success: 'Subscription added successfully' }, status: :created
+      end
+
       private
+
+      def subscription_params
+        params[:active] = true
+        params.require(:subscription).permit(:title, :price, :frequency, :customer_id, :tea_id, :active)
+      end
 
       def find_customer
         @customer = Customer.find_by(id: params[:customer_id])

--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -1,6 +1,7 @@
 module Api
   module V1
     class SubscriptionsController < ApplicationController
+      rescue_from ActiveRecord::RecordInvalid, with: :render_error
       before_action :find_customer, only: [:index, :create]
 
       def index
@@ -32,6 +33,10 @@ module Api
         else
           render json: ErrorSerializer.missing_parameter('customer_id'), status: :bad_request
         end
+      end
+
+      def render_error(error)
+        render json: ErrorSerializer.user_error(error.message), status: :bad_request
       end
     end
   end

--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -16,12 +16,13 @@ module Api
       private
 
       def subscription_params
-        params[:active] = true
-        params.require(:subscription).permit(:title, :price, :frequency, :customer_id, :tea_id, :active)
+        params[:frequency] = params[:frequency].to_i 
+        params.permit(:title, :price, :frequency, :customer_id, :tea_id, :active)
       end
 
       def find_customer
-        @customer = Customer.find_by(id: params[:customer_id])
+        id = params[:customer_id]
+        @customer = Customer.find_by(id: id)
         validate_customer
       end
 

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -7,8 +7,14 @@ class Subscription < ApplicationRecord
                         :frequency,
                         :customer_id,
                         :tea_id
-  validates :active, inclusion: { in: [true, false] }
   validates_numericality_of :frequency
 
   enum frequency: { weekly: 0, biweekly: 1, monthly: 2, quarterly: 3 }
+  after_initialize :set_active
+
+  private
+
+  def set_active
+    self.active ||= true
+  end
 end

--- a/app/serializers/error_serializer.rb
+++ b/app/serializers/error_serializer.rb
@@ -16,4 +16,13 @@ class ErrorSerializer
       }
     }
   end
+
+  def self.user_error(error)
+    {
+      "error": {
+        "code": 400,
+        "message": error
+      }
+    }
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
-      resources :subscriptions, only: :index
+      resources :subscriptions, only: [:index, :create]
     end
   end
 end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -12,9 +12,5 @@ RSpec.describe Subscription do
     it { should validate_presence_of :frequency }
     it { should validate_presence_of :customer_id }
     it { should validate_presence_of :tea_id }
-    it { should allow_value(true).for(:active)}
-    it { should allow_value(false).for(:active)}
-    it { should_not allow_value(nil).for(:active)}
-    it { should_not allow_value('').for(:active)}
   end
 end

--- a/spec/requests/subscriptions/create_spec.rb
+++ b/spec/requests/subscriptions/create_spec.rb
@@ -32,4 +32,137 @@ RSpec.describe 'post a new subscription for given customer' do
     expect(sub.frequency).to eq('biweekly')
     expect(sub.tea_id).to eq(tea.id)
   end
+
+  describe 'sad paths' do
+    it 'returns an error message if passed an invalid customer id' do
+      tea = create(:tea)
+
+      headers = {
+        'CONTENT_TYPE' => 'application/json',
+        'ACCEPT' => 'application/json'
+      }
+      body = {
+        title: 'Test Tea Subscription',
+        price: 5.99,
+        frequency: 1,
+        customer_id: 1,
+        tea_id: tea.id
+      }
+      post '/api/v1/subscriptions', headers: headers, params: body.to_json
+
+      error_message = JSON.parse(response.body, symbolize_names: true)
+
+      expect(response).to_not be_successful
+      expect(response).to have_http_status(400)
+      expect(error_message).to be_a Hash
+      expect(error_message.keys).to eq([:error])
+      expect(error_message[:error].keys.sort).to eq(%i[code message].sort)
+      expect(error_message[:error][:code]).to eq(400)
+      expect(error_message[:error][:message]).to eq('Invalid request, customer_id is invalid')
+    end
+
+    it 'returns an error message if passed an invalid tea id' do
+      cust = create(:customer)
+  
+      headers = {
+        'CONTENT_TYPE' => 'application/json',
+        'ACCEPT' => 'application/json'
+      }
+      body = {
+        title: 'Test Tea Subscription',
+        price: 5.99,
+        frequency: 1,
+        customer_id: cust.id,
+        tea_id: 1
+      }
+      post '/api/v1/subscriptions', headers: headers, params: body.to_json
+      
+      error_message = JSON.parse(response.body, symbolize_names: true)
+
+      expect(response).to_not be_successful
+      expect(response).to have_http_status(400)
+      expect(error_message).to be_a Hash
+      expect(error_message.keys).to eq([:error])
+      expect(error_message[:error].keys.sort).to eq(%i[code message].sort)
+      expect(error_message[:error][:code]).to eq(400)
+      expect(error_message[:error][:message]).to eq('Validation failed: Tea must exist')
+    end
+
+    it 'returns an error message if customer id is not passed' do
+      tea = create(:tea)
+  
+      headers = {
+        'CONTENT_TYPE' => 'application/json',
+        'ACCEPT' => 'application/json'
+      }
+      body = {
+        title: 'Test Tea Subscription',
+        price: 5.99,
+        frequency: 1,
+        tea_id: tea.id
+      }
+      post '/api/v1/subscriptions', headers: headers, params: body.to_json
+      
+      error_message = JSON.parse(response.body, symbolize_names: true)
+
+      expect(response).to_not be_successful
+      expect(response).to have_http_status(400)
+      expect(error_message).to be_a Hash
+      expect(error_message.keys).to eq([:error])
+      expect(error_message[:error].keys.sort).to eq(%i[code message].sort)
+      expect(error_message[:error][:code]).to eq(400)
+      expect(error_message[:error][:message]).to eq('Invalid request, customer_id is a required parameter')
+    end
+
+    it 'returns an error message tea id is not passed' do
+      cust = create(:customer)
+  
+      headers = {
+        'CONTENT_TYPE' => 'application/json',
+        'ACCEPT' => 'application/json'
+      }
+      body = {
+        title: 'Test Tea Subscription',
+        price: 5.99,
+        frequency: 1,
+        customer_id: cust.id
+      }
+      post '/api/v1/subscriptions', headers: headers, params: body.to_json
+      
+      error_message = JSON.parse(response.body, symbolize_names: true)
+
+      expect(response).to_not be_successful
+      expect(response).to have_http_status(400)
+      expect(error_message).to be_a Hash
+      expect(error_message.keys).to eq([:error])
+      expect(error_message[:error].keys.sort).to eq(%i[code message].sort)
+      expect(error_message[:error][:code]).to eq(400)
+      expect(error_message[:error][:message]).to eq("Validation failed: Tea must exist, Tea can't be blank")
+    end
+
+    it 'returns a validation error if missing other required params' do
+      cust = create(:customer)
+      tea = create(:tea)
+  
+      headers = {
+        'CONTENT_TYPE' => 'application/json',
+        'ACCEPT' => 'application/json'
+      }
+      body = {
+        customer_id: cust.id,
+        tea_id: tea.id
+      }
+      post '/api/v1/subscriptions', headers: headers, params: body.to_json
+  
+      error_message = JSON.parse(response.body, symbolize_names: true)
+
+      expect(response).to_not be_successful
+      expect(response).to have_http_status(400)
+      expect(error_message).to be_a Hash
+      expect(error_message.keys).to eq([:error])
+      expect(error_message[:error].keys.sort).to eq(%i[code message].sort)
+      expect(error_message[:error][:code]).to eq(400)
+      expect(error_message[:error][:message]).to eq("Validation failed: Title can't be blank, Price can't be blank, Frequency can't be blank, Frequency is not a number")
+    end
+  end
 end

--- a/spec/requests/subscriptions/create_spec.rb
+++ b/spec/requests/subscriptions/create_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe 'post a new subscription for given customer' do
+  it 'creates a new subscription for the given customer' do
+    cust = create(:customer)
+    tea = create(:tea)
+
+    headers = {
+      'CONTENT_TYPE' => 'application/json',
+      'ACCEPT' => 'application/json'
+    }
+    body = {
+      title: 'Test Tea Subscription',
+      price: 5.99,
+      frequency: 1,
+      customer_id: cust.id,
+      tea_id: tea.id
+    }
+    post '/api/v1/subscriptions', headers: headers, params: body.to_json
+
+    success_message = JSON.parse(response.body, symbolize_names: true)
+
+    expect(response).to have_http_status(201)
+    expect(success_message).to be_a Hash
+    expect(success_message).to eq({ success: 'Subscription added successfully' })
+    expect(cust.teas).to eq([tea])
+
+    sub = cust.subscriptions.last
+    
+    expect(sub.title).to eq('Test Tea Subscription')
+    expect(sub.price).to eq(5.99)
+    expect(sub.frequency).to eq('biweekly')
+    expect(sub.tea_id).to eq(tea.id)
+  end
+end


### PR DESCRIPTION
#3 Endpoint added to post a new subscription
Includes happy and sad path testing and error handling
### Example request: 
`post '/api/v1/subscriptions'`
Body
```
{
      "title": 'Test Tea Subscription',
      "price": 5.99,
      "frequency": 1,
      "customer_id": 5,
      "tea_id": 10
    }
```

### Example Response:
```
{
    "success": "Subscription added successfully"
}
```